### PR TITLE
No scipy

### DIFF
--- a/matrix.py
+++ b/matrix.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 import random
 import numpy as np
-from scipy import stats
 
 
 class Matrix:
@@ -220,10 +219,28 @@ class Matrix:
         a = np.ma.masked_equal(self.data[col], self.MISSING).compressed()
         return np.max(a)
 
+    def mode(a, axis=0): 
+    # taken from scipy code
+    # https://github.com/scipy/scipy/blob/master/scipy/stats/stats.py#L609
+        scores = np.unique(np.ravel(a))       # get ALL unique values
+        testshape = list(a.shape)
+        testshape[axis] = 1
+        oldmostfreq = np.zeros(testshape)
+        oldcounts = np.zeros(testshape)
+
+        for score in scores:
+            template = (a == score)
+            counts = np.expand_dims(np.sum(template, axis),axis)
+            mostfrequent = np.where(counts > oldcounts, score, oldmostfreq)
+            oldcounts = np.maximum(counts, oldcounts)
+            oldmostfreq = mostfrequent
+
+        return mostfrequent, oldcounts
+
     def most_common_value(self, col):
         """Get the most common value in the specified column"""
         a = np.ma.masked_equal(self.data[col], self.MISSING).compressed()
-        (val, count) = stats.mode(a)
+        (val, count) = mode(a)
         return val[0]
 
     def normalize(self):

--- a/matrix.py
+++ b/matrix.py
@@ -3,6 +3,24 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import random
 import numpy as np
 
+def mode(a, axis=0):
+# taken from scipy code
+# https://github.com/scipy/scipy/blob/master/scipy/stats/stats.py#L609
+    scores = np.unique(np.ravel(a))       # get ALL unique values
+    testshape = list(a.shape)
+    testshape[axis] = 1
+    oldmostfreq = np.zeros(testshape)
+    oldcounts = np.zeros(testshape)
+
+    for score in scores:
+        template = (a == score)
+        counts = np.expand_dims(np.sum(template, axis),axis)
+        mostfrequent = np.where(counts > oldcounts, score, oldmostfreq)
+        oldcounts = np.maximum(counts, oldcounts)
+        oldmostfreq = mostfrequent
+
+    return mostfrequent, oldcounts
+
 
 class Matrix:
 
@@ -218,24 +236,6 @@ class Matrix:
         """Get the max value in the specified column"""
         a = np.ma.masked_equal(self.data[col], self.MISSING).compressed()
         return np.max(a)
-
-    def mode(a, axis=0): 
-    # taken from scipy code
-    # https://github.com/scipy/scipy/blob/master/scipy/stats/stats.py#L609
-        scores = np.unique(np.ravel(a))       # get ALL unique values
-        testshape = list(a.shape)
-        testshape[axis] = 1
-        oldmostfreq = np.zeros(testshape)
-        oldcounts = np.zeros(testshape)
-
-        for score in scores:
-            template = (a == score)
-            counts = np.expand_dims(np.sum(template, axis),axis)
-            mostfrequent = np.where(counts > oldcounts, score, oldmostfreq)
-            oldcounts = np.maximum(counts, oldcounts)
-            oldmostfreq = mostfrequent
-
-        return mostfrequent, oldcounts
 
     def most_common_value(self, col):
         """Get the most common value in the specified column"""

--- a/test_baseline_learner.py
+++ b/test_baseline_learner.py
@@ -1,6 +1,6 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
-from unittest import TestCase
+from unittest import TestCase,TestLoader,TextTestRunner
 from baseline_learner import BaselineLearner
 from matrix import Matrix
 
@@ -8,7 +8,7 @@ from matrix import Matrix
 class TestBaselineLearner(TestCase):
 
     labels = Matrix()
-    labels.load_arff("tests/cm1_req.arff")
+    labels.load_arff("test/cm1_req.arff")
     l = BaselineLearner()
 
     def test_train(self):
@@ -21,3 +21,6 @@ class TestBaselineLearner(TestCase):
         self.l.predict([], labels)
 
         self.assertListEqual(self.l.labels, labels)
+
+suite = TestLoader().loadTestsFromTestCase(TestBaselineLearner)
+TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Scipy takes a long time to build, and the toolkit is only using a single method of a single module of the whole package ... the overhead might not be worth it in the long run (even if there's lots of good stuff in scipy). In this branch I ripped the 'mode' method from the scipy code and included it in the matrix module as a standalone global function (as it doesn't rely on anything else in scipy, only on some numpy modules); this way the toolkit can stand without that import. (Note that numpy may be harder to do this with, as it's really the standard for linear algebra and there would be lots to re-implement.)

This also has the added benefit of now being runnable on Google App Engine, as GAE allows numpy but not scipiy.

Finally, this branch also implements a routine on the test module so the test suite can be invoked from the command line.
